### PR TITLE
Reduce num of processors to 1 when processing dataset

### DIFF
--- a/src/speech_to_text_finetune/data_process.py
+++ b/src/speech_to_text_finetune/data_process.py
@@ -95,7 +95,7 @@ def process_dataset(
         _process_inputs_and_labels_for_whisper,
         fn_kwargs={"feature_extractor": feature_extractor, "tokenizer": tokenizer},
         remove_columns=dataset.column_names["train"],
-        num_proc=os.cpu_count(),
+        num_proc=1,
     )
     return dataset
 


### PR DESCRIPTION
Turns out that the processing is so fast, than adding more processors creates more overhead and makes mapping slower.

For `num_proc = 1`
Map:   3%|██                                                                 | 17997/574213 [03:13<1:14:44, 124.02 examples/s]

For `num_proc = 8`  (using os.cpu_count() on a 8 core CPU)
Map:   3%|██                                                                 | 13537/574213 [04:42<2:12:30, 30.11 examples/s]