### PR TITLE
Enable user to stop finetuning job prematurely

### DIFF
--- a/docs/step-by-step-guide.md
+++ b/docs/step-by-step-guide.md
@@ -65,6 +65,9 @@ Start by initially testing the quality of the Speech-to-Text models available in
 python src/speech_to_text_finetune/finetune_whisper.py
 ```
 
+> [!TIP]
+> You can prematurely and gracefully stop the finetuning job by pressing CTRL+C. The rest of the code (evaluation, uploading the model) will execute as normal.
+
 ### Step 4 - (Optional) Creating a finetuned STT model using CommonVoice data
 *Note: A Hugging Face account is required!*
 

--- a/src/speech_to_text_finetune/finetune_whisper.py
+++ b/src/speech_to_text_finetune/finetune_whisper.py
@@ -128,8 +128,12 @@ def run_finetuning(
         f"Start finetuning job on {dataset['train'].num_rows} audio samples. Monitor training metrics in real time in "
         f"a local tensorboard server by running in a new terminal: tensorboard --logdir {training_args.output_dir}/runs"
     )
-    trainer.train()
-    logger.info("Finetuning job complete.")
+    try:
+        trainer.train()
+    except KeyboardInterrupt:
+        logger.info("Stopping the finetuning job prematurely...")
+    else:
+        logger.info("Finetuning job complete.")
 
     logger.info(f"Start evaluation on {dataset['test'].num_rows} audio samples.")
     eval_results = trainer.evaluate()


### PR DESCRIPTION
# What's changing

User can exit the finetuning job gracefully, meaning that the training will stop, but the rest of the code will be executed as normally (evaluation, model & model card upload etc).

# How to test it

Steps to test the changes:

1. Start finetuning job: `python src/speech_to_text_finetune/finetune_whisper.py `
2. Press `Ctrl+C` in the terminal
3. You should see `Stopping the finetuning job prematurely...` and the code keep executing as normal

# Additional notes for reviewers

This is especially useful for long finetuning jobs when you see on Tensorboard that the model has already converged so there is no point in keep training.

# I already...

- [x] Tested the changes in a working environment to ensure they work as expected
- [ ] Added some tests for any new functionality
- [x] Updated the documentation (both comments in code and under `/docs`)
